### PR TITLE
Add MailDev integration and error handling to Contact Form

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { ArtisanPageComponent } from './pages/artisan-page/artisan-page.componen
 import { SearchResultComponent } from './pages/search-result/search-result.component';
 import { NgModule } from '@angular/core';
 import { NotFoundErrorComponent } from './pages/not-found-error/not-found-error.component';
+import { ResponseModalComponent } from './components/response-modal/response-modal.component';
 
 export const routes: Routes = [
     { path: '', redirectTo:'home', pathMatch:'full' },
@@ -12,12 +13,9 @@ export const routes: Routes = [
     { path:'result', component: SearchResultComponent },
     { path:'result/:category', component: SearchResultComponent },
     { path:'result/:search', component: SearchResultComponent },
+    { path:'modal', component: ResponseModalComponent },
+    
     { path:'**', component: NotFoundErrorComponent }
 ];
  
 
-@NgModule({
-    imports: [RouterModule.forRoot(routes)],
-    exports: [RouterModule]
-})
-export class AppRoutingModule {}

--- a/src/app/components/contact-form/contact-form.component.html
+++ b/src/app/components/contact-form/contact-form.component.html
@@ -1,20 +1,47 @@
 <section class="contact-form d-flex flex-column justify-content-center align-items-center w-100">
     <h1 class="contact-form__title text-center" >Contacter votre artisant</h1>
-    <form class="contact-form__form d-flex flex-column justify-content-center w-100">
+    <p class="contact-form__error w-100" id="error" *ngIf="!fieldOk">Tout les champ sont obligatoire</p>
+    <form class="contact-form__form d-flex flex-column justify-content-center w-100" (submit)="sendEmail()">
         <label for="name" class="contact-form__label">Nom</label>
-        <input type="text" id="name" name="name" class="contact-form__input">
+        <input type="text" id="name" name="name" class="contact-form__input" [ngClass]="{'empty-field': emptyFields.name}" [(ngModel)]="emailData.name" > 
 
         <label for="email" class="contact-form__label">Email</label>
-        <input type="email" id="email" name="email" class="contact-form__input">
+        <input  type="email" id="email" name="email" class="contact-form__input" [ngClass]="{'empty-field': emptyFields.from}" [(ngModel)]="emailData.from">
 
         <label for="subject" class="contact-form__label">Object</label>
-        <input type="text" id="subject" name="subject" class="contact-form__input">
+        <input type="text" id="subject" name="subject" class="contact-form__input" [ngClass]="{'empty-field': emptyFields.subject}" [(ngModel)]="emailData.subject" required>
 
         <label for="message" class="contact-form__label">Message</label>
-        <textarea id="message" name="message" class="contact-form__textarea"></textarea>
+        <textarea id="message" name="message" class="contact-form__textarea" [ngClass]="{'empty-field': emptyFields.body}" [(ngModel)]="emailData.body" required></textarea>
         <div class="contact-form__submit-container d-flex justify-content-end py-2">
-            <button type="submit" class="contact-form__submit d-flex justify-content-center align-items-center">Envoyer</button>
+            <button type="submit" class="contact-form__submit d-flex justify-content-center align-items-center"><div class="svg-wrapper-1">
+                <div class="svg-wrapper">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    height="24"
+                  >
+                    <path fill="none" d="M0 0h24v24H0z"></path>
+                    <path
+                      fill="currentColor"
+                      d="M1.946 9.315c-.522-.174-.527-.455.01-.634l19.087-6.362c.529-.176.832.12.684.638l-5.454 19.086c-.15.529-.455.547-.679.045L12 14l6-8-8 6-8.054-2.685z"
+                    ></path>
+                  </svg>
+                </div>
+              </div>
+              <span>Envoyer</span>
+            </button>
         </div>
-    </form>
+    </form >
+
+    <app-response-modal
+    *ngIf="showModal"
+    [mailStatus]="mailStatus"
+    [message]="message"
+    [loading]="loading"
+    (close)="closeModal()">
+    </app-response-modal>
+
 </section>
- 
+   

--- a/src/app/components/contact-form/contact-form.component.scss
+++ b/src/app/components/contact-form/contact-form.component.scss
@@ -1,4 +1,4 @@
-*{
+p{
     margin: 0;
 }
 .contact-form{
@@ -14,6 +14,12 @@
     color: #0074c7;
     font-size: 2rem;
     font-weight: 500;
+}
+
+.contact-form__error{
+  font-size: 1.25rem;
+  color: #cd2c2e;  
+  text-align: start;
 }
 
 .contact-form__form{
@@ -41,18 +47,88 @@
     min-height: 300px;
 }
 
-.contact-form__submit{
-    width: 160px;
-    padding: 10px;
-    color: #fff;
-    font-size: 1.25rem;
-    font-weight: normal;
-    background-color: #0074c7;
-    border: solid #00497c 1px;
-    border-radius: 15px;
+.empty-field{
+  background-color: #cd2c2f1a;
+  border-color: #CD2C2E;
 }
 
-.contact-form__submit:hover{
-    background-color: #00497c;
-    border-color: #0074c7;
+.contact-form__submit{
+    font-family: inherit;
+    font-size: 20px;
+    background: #0074c7;
+    color: white;
+    padding: 0.7em 1em;
+    padding-left: 0.9em;
+    display: flex;
+    align-items: center;
+    border: none;
+    border-radius: 16px;
+    overflow: hidden;
+    transition: all 0.2s;
+    cursor: pointer;
 }
+
+.contact-form__submit span{
+    display: block;
+    margin-left: 0.3em;
+    transition: all 0.3s ease-in-out;
+}
+
+.contact-form__submit svg {
+    display: block;
+    transform-origin: center center;
+    transition: transform 0.3s ease-in-out;
+  }
+
+  .contact-form__submit:hover{
+    background: #00497c;
+  }
+  
+  .contact-form__submit:hover .svg-wrapper {
+    animation: fly-1 0.6s ease-in-out infinite alternate;
+  }
+  
+  .contact-form__submit:hover svg {
+    transform: translateX(1.2em) rotate(45deg) scale(1.1);
+  }
+  
+  .contact-form__submit:hover span {
+    transform: translateX(5em);
+  }
+  
+  .contact-form__submit:active {
+    transform: scale(0.95);
+  }
+  
+  @keyframes fly-1 {
+    from {
+      transform: translateY(0.1em);
+    }
+  
+    to {
+      transform: translateY(-0.1em);
+    }
+  }
+
+  .shake{
+    animation: shake 0.2s;
+  }
+
+  @keyframes shake {
+    0% {
+      transform: translateX(0);
+    }
+    25% {
+      transform: translateX(-5px);
+    }
+    50% {
+      transform: translateX(5px);
+    }
+    75% {
+      transform: translateX(-5px);
+    }
+    100% {
+      transform: translateX(0);
+    }
+  }
+  

--- a/src/app/components/contact-form/contact-form.component.ts
+++ b/src/app/components/contact-form/contact-form.component.ts
@@ -1,12 +1,93 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { EmailService } from '../../services/email.service';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ResponseModalComponent } from '../response-modal/response-modal.component';
+import { CommonModule } from '@angular/common';
+
 
 @Component({
   selector: 'app-contact-form',
   standalone: true,
-  imports: [],
+  imports: [FormsModule, ReactiveFormsModule, ResponseModalComponent, CommonModule],
   templateUrl: './contact-form.component.html',
   styleUrl: './contact-form.component.scss'
 })
 export class ContactFormComponent {
+  @Input() artisanMail : any
+
+  message: string = '';
+  loading: boolean = false;
+  mailStatus: string = '';
+  fieldOk : boolean = true;
+  showModal : boolean = false;
+
+  emailData = {
+    name: '',
+    from : '',
+    to : '',
+    subject : '',
+    body : '' 
+  }
+
+  emptyFields: { name: boolean; from: boolean; subject: boolean; body: boolean } = {
+    name: false,
+    from: false,
+    subject: false,
+    body: false
+  };
+
+  constructor(private emailService : EmailService) {  }
+
+  sendEmail() {
+    this.checkFields()
+    if (this.fieldOk){
+      this.showModal = true
+      this.emailData.to = this.artisanMail
+      this.loading = true; // Start loading state
+      this.message = ''; // Clear previous messages
+
+      this.emailService.sendEmail(this.emailData).subscribe({
+      next: response => {
+        this.mailStatus = 'ok';
+        this.message = response.message;
+        this.loading = false; // Stop loading state
+      },
+      error: error => {
+        this.mailStatus = 'error'
+        this.message = `Erreur lors de l'envoi de l'e-mail: ${error.message}`;
+        this.loading = false; // Stop loading state
+      }
+    })
+    }else{
+      this.shakeAnimation()
+    }
+  }
+
+  checkFields(){
+    this.emptyFields = {
+      name: this.emailData.name?.replace(/\s+/g, '') === '',
+      from: this.emailData.from?.replace(/\s+/g, '') === '',
+      subject: this.emailData.subject?.replace(/\s+/g, '') === '',
+      body: this.emailData.body?.replace(/\s+/g, '') === ''
+    };
+
+    this.fieldOk = !(this.emptyFields.name || this.emptyFields.from || this.emptyFields.subject || this.emptyFields.body)
+  }
+
+  shakeAnimation(){
+    setTimeout(()=>{
+      let errorMessage = document.getElementById('error')
+      if (errorMessage){
+      errorMessage.classList.add('shake')
+      setTimeout(() => {
+        errorMessage.classList.remove('shake')
+      }, 250)
+    }
+    }, 1)
+  }
+
+  closeModal(){
+    this.showModal = false;
+  }
 
 }

--- a/src/app/components/response-modal/response-modal.component.html
+++ b/src/app/components/response-modal/response-modal.component.html
@@ -1,0 +1,15 @@
+
+    <div class="modal fade show" id="responseModal" tabindex="-1" aria-labelledby="responseModalLabel" aria-modal="true" role="dialog" style="display: block;"  >
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" (click)="closeModal()"></button>
+            </div>
+            <div class="modal-body d-flex flex-column align-items-center justify-content-center">
+                <div *ngIf="loading" class="spinner"></div>
+                <p *ngIf="!loading" class="modal-message {{ mailStatus }}">{{ message }}</p>
+            </div>
+            <div class="modal-backdrop w-100 h-100" (click)="closeModal()"></div>
+          </div>
+        </div>
+    </div>

--- a/src/app/components/response-modal/response-modal.component.scss
+++ b/src/app/components/response-modal/response-modal.component.scss
@@ -1,0 +1,88 @@
+.modal{
+    --bs-modal-bg: #f1f8fc;
+}
+
+.modal-backdrop{
+  z-index: -1000;
+  background-color: rgba(0, 0, 0, 0.548);
+}
+
+.modal-header{
+    border-bottom: none
+}
+
+.modal-message{
+    font-size: 1.5rem;
+}
+
+.ok{
+  color:#82b864 ;
+}
+
+.error{
+  color: #cd2c2e;
+}
+
+.spinner {
+    --size: 30px;
+    --color: #0074c7;
+    width: 100px;
+    height: 100px;
+    position: relative;
+  }
+  
+  .spinner::after,.spinner::before {
+    box-sizing: border-box;
+    position: absolute;
+    content: "";
+    width: var(--size);
+    height: var(--size);
+    top: 50%;
+    animation: up 2.4s cubic-bezier(0, 0, 0.24, 1.21) infinite;
+    left: 50%;
+    background: var(--color);
+    box-shadow: 0 0 calc(var(--size) / 3) #00497c;
+  }
+  
+  .spinner::after {
+    background: var(--color);
+    top: calc(50% - var(--size));
+    left: calc(50% - var(--size));
+    animation: down 2.4s cubic-bezier(0, 0, 0.24, 1.21) infinite;
+  }
+  
+  @keyframes down {
+    0%, 100% {
+      transform: none;
+    }
+  
+    25% {
+      transform: translateX(100%);
+    }
+  
+    50% {
+      transform: translateX(100%) translateY(100%);
+    }
+  
+    75% {
+      transform: translateY(100%);
+    }
+  }
+  
+  @keyframes up {
+    0%, 100% {
+      transform: none;
+    }
+  
+    25% {
+      transform: translateX(-100%);
+    }
+  
+    50% {
+      transform: translateX(-100%) translateY(-100%);
+    }
+  
+    75% {
+      transform: translateY(-100%);
+    }
+  }

--- a/src/app/components/response-modal/response-modal.component.spec.ts
+++ b/src/app/components/response-modal/response-modal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ResponseModalComponent } from './response-modal.component';
+
+describe('ResponseModalComponent', () => {
+  let component: ResponseModalComponent;
+  let fixture: ComponentFixture<ResponseModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResponseModalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ResponseModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/response-modal/response-modal.component.ts
+++ b/src/app/components/response-modal/response-modal.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+
+@Component({
+  selector: 'app-response-modal',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './response-modal.component.html',
+  styleUrl: './response-modal.component.scss'
+})
+export class ResponseModalComponent {
+  @Input() mailStatus : string = '';
+  @Input() message : string = "";
+  @Input() loading : boolean = false;
+
+  @Output() close: EventEmitter<void> = new EventEmitter<void>();
+
+  closeModal(){
+    this.close.emit();
+  }
+
+}
+ 

--- a/src/app/pages/artisan-page/artisan-page.component.html
+++ b/src/app/pages/artisan-page/artisan-page.component.html
@@ -26,5 +26,5 @@
         </div>
     </section>
 
-    <app-contact-form class="w-100 d-flex justify-content-center align-items-center"></app-contact-form>
+    <app-contact-form class="w-100 d-flex justify-content-center align-items-center" [artisanMail]="artisan.email" ></app-contact-form>
 </main>

--- a/src/app/services/email.service.spec.ts
+++ b/src/app/services/email.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { EmailService } from './email.service';
+
+describe('EmailService', () => {
+  let service: EmailService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(EmailService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/email.service.ts
+++ b/src/app/services/email.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EmailService {
+
+  private apiUrl = 'http://localhost:3000/send-email';
+
+  constructor(private http: HttpClient) { }
+
+  sendEmail(emailData: {name:string, from: string, to: string, subject: string, body: string }): Observable<any> {
+    return this.http.post(this.apiUrl, emailData).pipe(
+      catchError(this.handleError)
+    );
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    let errorMessage = 'Unknown error!';
+
+    console.log("service" ,error)
+
+    if (error.error instanceof ErrorEvent) {
+      // A client-side or network error occurred.
+      errorMessage = `Error: ${error.error.message}`;
+    } else {
+      // Backend returned an unsuccessful response code.
+      // Error body should contain the error message
+    if (error.error && error.error.message) {
+      errorMessage = `${error.error.message}`;
+    } else {
+      errorMessage = `Server Error: ${error.status}\nMessage: ${error.message}`;
+    }
+    }
+    return throwError(() => new Error(errorMessage));
+  }
+}


### PR DESCRIPTION
- Implemented a local server setup utilizing MailDev to test sending emails from the contact form in the Artisan Page.
- Integrated the `sendEmail` function from `email.service` to handle email submissions, with robust error handling using `HttpErrorResponse`.
- Enhanced the `sendEmail` function to throw appropriate error messages which are then captured and used in the `contact-form` component.
- Developed a modal component (`response-modal.component`) to display error or success messages based on the email submission status.
- Introduced `checkFields` function in `contact-form.component` to validate if form fields are not empty and set the `fieldsOk` property accordingly.
- Managed the visibility and state of the modal and other UI elements through properties like `showModal`, `mailStatus`, `message`, `loading`, and `fieldsOk`.